### PR TITLE
Improve performance, reduce memory footprint during parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
                     <systemPropertyVariables>
                         <test.build.data>${project.basedir}/target/test-data/</test.build.data>
                     </systemPropertyVariables>
-                    <argLine>-Xmx1024m</argLine>
+                    <argLine>-Xmx900m</argLine>
                     <forkMode>always</forkMode>
                     <testFailureIgnore>false</testFailureIgnore>
                 </configuration>
@@ -332,7 +332,8 @@
         <org.junit.jupiter.version>5.7.2</org.junit.jupiter.version>
         <slf4j-log4j12.version>1.7.7</slf4j-log4j12.version>
         <jena.version>4.1.0</jena.version>
-        <expresstoowl.version>0.4</expresstoowl.version>
+        <expresstoowl.version>0.5-SNAPSHOT</expresstoowl.version>
+        <ifcparserlib.version>0.3-SNAPSHOT</ifcparserlib.version>
         <!-- Maven Plugin Dependencies -->
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
@@ -376,24 +377,18 @@
             <version>${expresstoowl.version}</version>
             <scope>compile</scope>
         </dependency>
-        <!--<dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-simple</artifactId>
-          <version>1.7.25</version>
-          <scope>runtime</scope>
-        </dependency>-->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.6</version>
+            <version>1.7.31</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.5</version>
-            <scope>compile</scope>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
         </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/be/ugent/IfcSpfReader.java
+++ b/src/main/java/be/ugent/IfcSpfReader.java
@@ -29,12 +29,14 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.ontology.OntModelSpec;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.system.StreamRDF;
 import org.apache.jena.riot.web.HttpOp;
 import org.apache.jena.sparql.graph.GraphFactory;
 import org.slf4j.Logger;
@@ -306,39 +308,34 @@ public class IfcSpfReader {
 
     @SuppressWarnings("unchecked")
 	public void convert(String ifcFile, String outputFile, String baseURI) throws IOException {
-		// CONVERSION
-		OntModel om = null;
-
-		in = null;
-		HttpOp.setDefaultHttpClient(HttpClientBuilder.create().useSystemProperties().build());
-		om = ModelFactory.createOntologyModel(OntModelSpec.OWL_DL_MEM_TRANS_INF);
-		in = IfcSpfReader.class.getResourceAsStream("/" + exp + ".ttl");
-		if (in == null)
-			in = IfcSpfReader.class.getResourceAsStream("/resources/" + exp + ".ttl");  // Eclipse FIX
-		
-		om.read(in, null, "TTL");
-
-		try {
-			RDFWriter conv = new RDFWriter(om, new FileInputStream(ifcFile), baseURI, ent, typ, ontURI);
-			conv.setRemoveDuplicates(removeDuplicates);
+    	convert(ifcFile, baseURI, writer -> {
 			try (FileOutputStream out = new FileOutputStream(outputFile)) {
 				String s = "# baseURI: " + baseURI;
 				s += "\r\n# imports: " + ontURI + "\r\n\r\n";
 				out.write(s.getBytes());
 				LOG.info("Started parsing stream");
-				conv.parseModelToOutputStream(out);
+				writer.parseModelToOutputStream(out);
 				LOG.info("Finished!!");
+			} catch (Exception e) {
+				throw new RuntimeException(String.format("Could not write output %s: %s", outputFile, e.getMessage() ));
 			}
-		} catch (FileNotFoundException e1) {
-			e1.printStackTrace();
-		} finally {
-			try {
-				in.close();
-			} catch (Exception e1) {
-				e1.printStackTrace();
-			}
+		});
+	}
+
+	public void convert(String ifcFile, String baseURI, Consumer<RDFWriter> handler){
+		// CONVERSION
+		OntModel om = readOntology();
+		try (InputStream in = new FileInputStream(ifcFile)){
+			RDFWriter conv = new RDFWriter(om, in, baseURI, ent, typ, ontURI);
+			conv.setRemoveDuplicates(removeDuplicates);
+			LOG.info("Started parsing stream");
+			handler.accept(conv);
+			LOG.info("Finished!!");
+		} catch (Exception e) {
+			throw new RuntimeException(String.format("Error converting file %s: %s", ifcFile, e.getMessage()));
 		}
 	}
+
 
 	public Graph convert(String ifcFile, String baseURI) throws IOException {
 		Graph graph = GraphFactory.createGraphMem();
@@ -348,31 +345,35 @@ public class IfcSpfReader {
 
 	@SuppressWarnings("unchecked")
 	public void convert(String ifcFile, Graph toGraph, String baseURI) throws IOException {
-		// CONVERSION
-		OntModel om = null;
+		convert(ifcFile, baseURI, writer -> {
+			try {
+				writer.parseModelToGraph(toGraph);
+			} catch (Exception e) {
+				throw new RuntimeException(String.format("Error converting file %s: %s", ifcFile, e.getMessage()));
+			}
+		});
+	}
 
+	public void convert(String ifcFile, StreamRDF streamRDF, String baseURI) throws IOException {
+		convert(ifcFile, baseURI, writer -> {
+			try {
+				writer.parseModelToStreamRdf(streamRDF);
+			} catch (Exception e) {
+				throw new RuntimeException(String.format("Error converting file %s: %s", ifcFile, e.getMessage()));
+			}
+		});
+	}
+
+	private OntModel readOntology() {
+		OntModel om = null;
 		in = null;
 		HttpOp.setDefaultHttpClient(HttpClientBuilder.create().useSystemProperties().build());
 		om = ModelFactory.createOntologyModel(OntModelSpec.OWL_DL_MEM_TRANS_INF);
 		in = IfcSpfReader.class.getResourceAsStream("/" + exp + ".ttl");
 		if (in == null)
 			in = IfcSpfReader.class.getResourceAsStream("/resources/" + exp + ".ttl");  // Eclipse FIX
-
 		om.read(in, null, "TTL");
-
-		try {
-			RDFWriter conv = new RDFWriter(om, new FileInputStream(ifcFile), baseURI, ent, typ, ontURI);
-			conv.setRemoveDuplicates(removeDuplicates);
-			LOG.info("Started parsing stream");
-			conv.parseModelToGraph(toGraph);
-			LOG.info("Finished!!");
-		} finally {
-			try {
-				in.close();
-			} catch (Exception e1) {
-				e1.printStackTrace();
-			}
-		}
+		return om;
 	}
 
     public void setRemoveDuplicates(boolean val) {

--- a/src/main/java/be/ugent/IfcSpfReader.java
+++ b/src/main/java/be/ugent/IfcSpfReader.java
@@ -317,7 +317,7 @@ public class IfcSpfReader {
 				writer.parseModelToOutputStream(out);
 				LOG.info("Finished!!");
 			} catch (Exception e) {
-				throw new RuntimeException(String.format("Could not write output %s: %s", outputFile, e.getMessage() ));
+				throw new RuntimeException(String.format("Could not write output %s: %s", outputFile, e.getMessage() ), e);
 			}
 		});
 	}
@@ -332,7 +332,7 @@ public class IfcSpfReader {
 			handler.accept(conv);
 			LOG.info("Finished!!");
 		} catch (Exception e) {
-			throw new RuntimeException(String.format("Error converting file %s: %s", ifcFile, e.getMessage()));
+			throw new RuntimeException(String.format("Error converting file %s: %s", ifcFile, e.getMessage()), e);
 		}
 	}
 
@@ -349,7 +349,7 @@ public class IfcSpfReader {
 			try {
 				writer.parseModelToGraph(toGraph);
 			} catch (Exception e) {
-				throw new RuntimeException(String.format("Error converting file %s: %s", ifcFile, e.getMessage()));
+				throw new RuntimeException(String.format("Error converting file %s: %s", ifcFile, e.getMessage()), e);
 			}
 		});
 	}
@@ -359,7 +359,7 @@ public class IfcSpfReader {
 			try {
 				writer.parseModelToStreamRdf(streamRDF);
 			} catch (Exception e) {
-				throw new RuntimeException(String.format("Error converting file %s: %s", ifcFile, e.getMessage()));
+				throw new RuntimeException(String.format("Error converting file %s: %s", ifcFile, e.getMessage()), e);
 			}
 		});
 	}

--- a/src/main/java/be/ugent/RDFWriter.java
+++ b/src/main/java/be/ugent/RDFWriter.java
@@ -120,7 +120,7 @@ public class RDFWriter {
     ttlWriter.start();
     ttlWriter.triple(new Triple(NodeFactory.createURI(baseURI), RDF.type.asNode(), OWL.Ontology.asNode()));
     ttlWriter.triple(new Triple(NodeFactory.createURI(baseURI), OWL.imports.asNode(), NodeFactory.createURI(ontNS)));
-    IfcSpfParser parser = new IfcSpfParser(inputStream);
+    IfcSpfParser parser = new IfcSpfParser(inputStream, removeDuplicates);
     // Read the whole file into a linemap Map object
     parser.readModel();
     LOG.info("Model parsed");
@@ -202,7 +202,7 @@ public class RDFWriter {
           LOG.warn("*WARNING 1*: fillProperties 2: unhandled type property found.");
         } else if (IFCVO.class.isInstance(o)) {
           LOG.warn("*WARNING 2*: fillProperties 2: unhandled type property found.");
-        } else if (LinkedList.class.isInstance(o)) {
+        } else if (List.class.isAssignableFrom(o.getClass())) {
           if (LOG.isDebugEnabled()) {
             LOG.debug("fillProperties 3 - fillPropertiesHandleListObject(tvo)");
           }
@@ -233,7 +233,7 @@ public class RDFWriter {
             LOG.debug("fillProperties 5 - fillPropertiesHandleIfcObject(evo)");
           }
           attributePointer = fillPropertiesHandleIfcObject(r, evo, attributePointer, o);
-        } else if (LinkedList.class.isInstance(o)) {
+        } else if (List.class.isAssignableFrom(o.getClass())) {
           if (LOG.isDebugEnabled()) {
             LOG.debug("fillProperties 6 - fillPropertiesHandleListObject(evo)");
           }
@@ -322,10 +322,10 @@ public class RDFWriter {
   @SuppressWarnings("unchecked")
   private int fillPropertiesHandleListObject(Resource r, EntityVO evo, int attributePointer, Object o) throws IOException {
 
-    final LinkedList<Object> tmpList = (LinkedList<Object>) o;
-    LinkedList<String> literals = new LinkedList<>();
-    LinkedList<Resource> listRemembranceResources = new LinkedList<>();
-    LinkedList<IFCVO> ifcVOs = new LinkedList<>();
+    final List<Object> tmpList = (List<Object>) o;
+    List<String> literals = new LinkedList<>();
+    List<Resource> listRemembranceResources = new LinkedList<>();
+    List<IFCVO> ifcVOs = new LinkedList<>();
 
     // process list
     for (int j = 0; j < tmpList.size(); j++) {
@@ -389,9 +389,9 @@ public class RDFWriter {
         } else {
           LOG.warn("*WARNING 13*: Nothing happened. Not sure if this is good or bad, possible or not.");
         }
-      } else if (LinkedList.class.isInstance(o1)) {
+      } else if (List.class.isAssignableFrom(o1.getClass())) {
         if (typeRemembrance != null) {
-          LinkedList<Object> tmpListInList = (LinkedList<Object>) o1;
+          List<Object> tmpListInList = (List<Object>) o1;
           for (int jj = 0; jj < tmpListInList.size(); jj++) {
             Object o2 = tmpListInList.get(jj);
             if (Character.class.isInstance(o2)) {
@@ -403,13 +403,13 @@ public class RDFWriter {
             } else if (IFCVO.class.isInstance(o2)) {
               // Lists of IFC entities
               LOG.warn("*WARNING 30: Nothing happened. Not sure if this is good or bad, possible or not.");
-            } else if (LinkedList.class.isInstance(o2)) {
+            } else if (List.class.isAssignableFrom(o2.getClass())) {
               // this happens only for types that are equivalent
               // to lists (e.g. IfcLineIndex in IFC4_ADD1)
               // in this case, the elements of the list should be
               // treated as new instances that are equivalent to
               // the correct lists
-              LinkedList<Object> tmpListInListInList = (LinkedList<Object>) o2;
+              List<Object> tmpListInListInList = (List<Object>) o2;
               for (int jjj = 0; jjj < tmpListInListInList.size(); jjj++) {
                 Object o3 = tmpListInListInList.get(jjj);
                 if (Character.class.isInstance(o3)) {
@@ -462,7 +462,7 @@ public class RDFWriter {
             }
           }
         } else {
-          LinkedList<Object> tmpListInList = (LinkedList<Object>) o1;
+          List<Object> tmpListInList = (List<Object>) o1;
           for (int jj = 0; jj < tmpListInList.size(); jj++) {
             Object o2 = tmpListInList.get(jj);
             if (Character.class.isInstance(o2)) {
@@ -473,7 +473,7 @@ public class RDFWriter {
               literals.add(filterExtras((String) o2));
             } else if (IFCVO.class.isInstance(o2)) {
               ifcVOs.add((IFCVO) o2);
-            } else if (LinkedList.class.isInstance(o2)) {
+            } else if (List.class.isAssignableFrom(o2.getClass())) {
               LOG.error("*ERROR 19*: Found List of List of List. Code cannot handle that.");
             } else {
               LOG.warn("*WARNING 32*: Nothing happened. Not sure if this is good or bad, possible or not.");
@@ -524,7 +524,7 @@ public class RDFWriter {
           if (typerange.asClass().hasSuperClass(ontModel.getOntClass(LIST_NS + "OWLList")))
             addRegularListProperty(r, p, literals, typeRemembrance);
           else {
-            addSinglePropertyFromTypeRemembrance(r, p, literals.getFirst(), typeRemembrance);
+            addSinglePropertyFromTypeRemembrance(r, p, literals.get(0), typeRemembrance);
             if (literals.size() > 1) {
               LOG.warn("*WARNING 37*: We are ignoring a number of literal values here.");
             }
@@ -558,8 +558,8 @@ public class RDFWriter {
   @SuppressWarnings({ "unchecked" })
   private void fillPropertiesHandleListObject(Resource r, TypeVO tvo, Object o) throws IOException {
 
-    final LinkedList<Object> tmpList = (LinkedList<Object>) o;
-    LinkedList<String> literals = new LinkedList<>();
+    final List<Object> tmpList = (List<Object>) o;
+    List<String> literals = new LinkedList<>();
 
     // process list
     for (int j = 0; j < tmpList.size(); j++) {
@@ -580,8 +580,8 @@ public class RDFWriter {
         } else {
           LOG.warn("*WARNING 19*: Nothing happened. Not sure if this is good or bad, possible or not.");
         }
-      } else if (LinkedList.class.isInstance(o1) && typeRemembrance != null) {
-        LinkedList<Object> tmpListInlist = (LinkedList<Object>) o1;
+      } else if (List.class.isAssignableFrom(o1.getClass()) && typeRemembrance != null) {
+        List<Object> tmpListInlist = (List<Object>) o1;
         for (int jj = 0; jj < tmpListInlist.size(); jj++) {
           Object o2 = tmpListInlist.get(jj);
           if (String.class.isInstance(o2)) {
@@ -872,7 +872,7 @@ public class RDFWriter {
     }
   }
 
-  private void fillClassInstanceList(LinkedList<Object> tmpList, OntResource typerange, OntProperty p, Resource r) throws IOException {
+  private void fillClassInstanceList(List<Object> tmpList, OntResource typerange, OntProperty p, Resource r) throws IOException {
     List<Resource> reslist = new ArrayList<>();
     List<IFCVO> entlist = new ArrayList<>();
 

--- a/src/main/java/be/ugent/RDFWriter.java
+++ b/src/main/java/be/ugent/RDFWriter.java
@@ -103,6 +103,11 @@ public class RDFWriter {
     parseModelToOutputStream();
   }
 
+  public void parseModelToStreamRdf(StreamRDF writer) throws IOException {
+    ttlWriter = writer;
+    parseModelToOutputStream();
+  }
+
   private void parseModelToOutputStream() throws IOException {
     ttlWriter.base(baseURI);
     ttlWriter.prefix("ifc", ontNS);

--- a/src/main/java/be/ugent/RDFWriter.java
+++ b/src/main/java/be/ugent/RDFWriter.java
@@ -162,10 +162,11 @@ public class RDFWriter {
       }
       listOfUniqueResources.put(ifcLineEntry.getFullLineAfterNum(), r);
 
-      LOG.info("-------------------------------");
-      LOG.info(r.getLocalName());
-      LOG.info("-------------------------------");
-
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("-------------------------------");
+        LOG.debug(r.getLocalName());
+        LOG.debug("-------------------------------");
+      }
       fillProperties(ifcLineEntry, r);
     }
     // The map is used only to avoid duplicates.
@@ -202,7 +203,9 @@ public class RDFWriter {
         } else if (IFCVO.class.isInstance(o)) {
           LOG.warn("*WARNING 2*: fillProperties 2: unhandled type property found.");
         } else if (LinkedList.class.isInstance(o)) {
-          LOG.info("fillProperties 3 - fillPropertiesHandleListObject(tvo)");
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("fillProperties 3 - fillPropertiesHandleListObject(tvo)");
+          }
           fillPropertiesHandleListObject(r, tvo, o);
         }
       }
@@ -221,13 +224,19 @@ public class RDFWriter {
             LOG.error("*ERROR 18*: We found a character that is not a comma. That should not be possible!");
           }
         } else if (String.class.isInstance(o)) {
-          LOG.info("fillProperties 4 - fillPropertiesHandleStringObject(evo)");
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("fillProperties 4 - fillPropertiesHandleStringObject(evo)");
+          }
           attributePointer = fillPropertiesHandleStringObject(r, evo, subject, attributePointer, o);
         } else if (IFCVO.class.isInstance(o)) {
-          LOG.info("fillProperties 5 - fillPropertiesHandleIfcObject(evo)");
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("fillProperties 5 - fillPropertiesHandleIfcObject(evo)");
+          }
           attributePointer = fillPropertiesHandleIfcObject(r, evo, attributePointer, o);
         } else if (LinkedList.class.isInstance(o)) {
-          LOG.info("fillProperties 6 - fillPropertiesHandleListObject(evo)");
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("fillProperties 6 - fillPropertiesHandleListObject(evo)");
+          }
           attributePointer = fillPropertiesHandleListObject(r, evo, attributePointer, o);
         }
       }
@@ -260,17 +269,22 @@ public class RDFWriter {
               addEnumProperty(r, p, range, literalString);
             } else if (range.asClass().hasSuperClass(ontModel.getOntClass(EXPRESS_NS + "SELECT"))) {
               // Check for SELECT
-              LOG.info("*OK 25*: found subClass of SELECT Class, now doing nothing with it: " + p + " - " + range.getLocalName() + " - " + literalString);
+              if (LOG.isDebugEnabled()) {
+                LOG.debug("*OK 25*: found subClass of SELECT Class, now doing nothing with it: {} - {} - {}", p,
+                                range.getLocalName(), literalString);
+              }
               createLiteralProperty(r, p, range, literalString);
             } else if (range.asClass().hasSuperClass(ontModel.getOntClass(LIST_NS + "OWLList"))) {
               // Check for LIST
-              LOG.info("*WARNING 5*: found LIST property (but doing nothing with it): " + subject + " -- " + p + " - " + range.getLocalName() + " - "
-                      + literalString);
+              if (LOG.isDebugEnabled()) {
+                LOG.debug("*WARNING 5*: found LIST property (but doing nothing with it): {} -- {} - {} - {}",
+                                new Object[] { subject, p, range.getLocalName(), literalString });
+              }
             } else {
               createLiteralProperty(r, p, range, literalString);
             }
           } else {
-            LOG.warn("*WARNING 7*: found other kind of property: " + p + " - " + range.getLocalName());
+            LOG.warn("*WARNING 7*: found other kind of property: {} - {}", p ,range.getLocalName());
           }
         } else {
           LOG.warn("*WARNING 8*: Nothing happened. Not sure if this is good or bad, possible or not.");
@@ -295,7 +309,9 @@ public class RDFWriter {
 
       Resource r1 = getResource(baseURI + evorange.getName() + "_" + ((IFCVO) o).getLineNum(), rclass);
       ttlWriter.triple(new Triple(r.asNode(), p.asNode(), r1.asNode()));
-      LOG.info("*OK 1*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1.getLocalName());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("*OK 1*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1.getLocalName());
+      }
     } else {
       LOG.warn("*WARNING 3*: Nothing happened. Not sure if this is good or bad, possible or not.");
     }
@@ -364,7 +380,11 @@ public class RDFWriter {
 
             Resource r1 = getResource(baseURI + evorange.getName() + "_" + ((IFCVO) o1).getLineNum(), rclass);
             ttlWriter.triple(new Triple(r.asNode(), p.asNode(), r1.asNode()));
-            LOG.info("*OK 5*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1.getLocalName());
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("*OK 5*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1
+                              .getLocalName());
+            }
+
           }
         } else {
           LOG.warn("*WARNING 13*: Nothing happened. Not sure if this is good or bad, possible or not.");
@@ -619,7 +639,10 @@ public class RDFWriter {
         addEnumProperty(r, p, range, literalString);
       } else if (range.asClass().hasSuperClass(ontModel.getOntClass(EXPRESS_NS + "SELECT"))) {
         // Check for SELECT
-        LOG.info("*OK 24*: found subClass of SELECT Class, now doing nothing with it: " + p + " - " + range.getLocalName() + " - " + literalString);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("*OK 24*: found subClass of SELECT Class, now doing nothing with it: " + p + " - " + range
+                          .getLocalName() + " - " + literalString);
+        }
         createLiteralProperty(r, p, range, literalString);
       } else if (range.asClass().hasSuperClass(ontModel.getOntClass(LIST_NS + "OWLList"))) {
         // Check for LIST
@@ -637,7 +660,10 @@ public class RDFWriter {
       OntResource rangeInstance = instances.next();
       if (rangeInstance.getProperty(RDFS.label).getString().equalsIgnoreCase(filterPoints(literalString))) {
         ttlWriter.triple(new Triple(r.asNode(), p.asNode(), rangeInstance.asNode()));
-        LOG.info("*OK 2*: added ENUM statement " + r.getLocalName() + " - " + p.getLocalName() + " - " + rangeInstance.getLocalName());
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("*OK 2*: added ENUM statement " + r.getLocalName() + " - " + p.getLocalName() + " - "
+                          + rangeInstance.getLocalName());
+        }
         return;
       }
     }
@@ -671,8 +697,9 @@ public class RDFWriter {
       addLiteral(r1, valueProp, ResourceFactory.createTypedLiteral(literalString, XSDDatatype.XSDstring));
     else
       addLiteral(r1, valueProp, ResourceFactory.createTypedLiteral(literalString));
-
-    LOG.info("*OK 4*: added literal: " + r1.getLocalName() + " - " + valueProp + " - " + literalString);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("*OK 4*: added literal: " + r1.getLocalName() + " - " + valueProp + " - " + literalString);
+    }
   }
 
   // LIST HANDLING
@@ -709,14 +736,22 @@ public class RDFWriter {
             EntityVO evorange = ent.get(ExpressReader.formatClassName((vo).getName()));
             OntResource rclass = ontModel.getOntResource(ontNS + evorange.getName());
             Resource r2 = getResource(baseURI + evorange.getName() + "_" + (vo).getLineNum(), rclass);
-            LOG.info("*OK 21*: created resource: " + r2.getLocalName());
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("*OK 21*: created resource: " + r2.getLocalName());
+            }
             idCounter++;
             ttlWriter.triple(new Triple(r1.asNode(), ontModel.getOntProperty(LIST_NS + "hasContents").asNode(), r2.asNode()));
-            LOG.info("*OK 22*: added property: " + r1.getLocalName() + " - " + "-hasContents-" + " - " + r2.getLocalName());
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("*OK 22*: added property: " + r1.getLocalName() + " - " + "-hasContents-" + " - " + r2
+                              .getLocalName());
+            }
 
             if (i < el.size() - 1) {
               ttlWriter.triple(new Triple(r1.asNode(), ontModel.getOntProperty(LIST_NS + "hasNext").asNode(), reslist.get(i + 1).asNode()));
-              LOG.info("*OK 23*: added property: " + r1.getLocalName() + " - " + "-hasNext-" + " - " + reslist.get(i + 1).getLocalName());
+              if (LOG.isDebugEnabled()) {
+                LOG.debug("*OK 23*: added property: " + r1.getLocalName() + " - " + "-hasNext-" + " - " + reslist
+                                .get(i + 1).getLocalName());
+              }
             }
           }
         }
@@ -747,7 +782,10 @@ public class RDFWriter {
             idCounter++;
             if (ii == 0) {
               ttlWriter.triple(new Triple(r.asNode(), p.asNode(), r1.asNode()));
-              LOG.info("*OK 7*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1.getLocalName());
+              if (LOG.isDebugEnabled()) {
+                LOG.debug("*OK 7*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1
+                                .getLocalName());
+              }
             }
           }
           // bindtheproperties
@@ -771,13 +809,17 @@ public class RDFWriter {
       if (r1 == null) {
         r1 = ResourceFactory.createResource(baseURI + range.getLocalName() + "_" + idCounter);
         ttlWriter.triple(new Triple(r1.asNode(), RDF.type.asNode(), range.asNode()));
-        LOG.info("*OK 17*: created resource: " + r1.getLocalName());
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("*OK 17*: created resource: " + r1.getLocalName());
+        }
         idCounter++;
         propertyResourceMap.put(key, r1);
         addLiteralToResource(r1, valueProp, xsdType, literalString);
       }
       ttlWriter.triple(new Triple(r.asNode(), p.asNode(), r1.asNode()));
-      LOG.info("*OK 3*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1.getLocalName());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("*OK 3*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1.getLocalName());
+      }
     } else {
       LOG.error("*ERROR 1*: XSD type not found for: " + p + " - " + range.getURI() + " - " + literalString);
     }
@@ -790,7 +832,9 @@ public class RDFWriter {
 
       if (listrange != null) {
         if (listrange.asClass().hasSuperClass(ontModel.getOntClass(LIST_NS + "OWLList"))) {
-          LOG.info("*OK 20*: Handling list of list");
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("*OK 20*: Handling list of list");
+          }
           listrange = range;
         }
         for (int i = 0; i < el.size(); i++) {
@@ -798,20 +842,30 @@ public class RDFWriter {
           Resource r2 = ResourceFactory.createResource(baseURI + range.getLocalName() + "_" + idCounter); // was
           // listrange
           ttlWriter.triple(new Triple(r2.asNode(), RDF.type.asNode(), range.asNode()));
-          LOG.info("*OK 14*: added property: " + r2.getLocalName() + " - rdf:type - " + range.getLocalName());
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("*OK 14*: added property: " + r2.getLocalName() + " - rdf:type - " + range.getLocalName());
+          }
           idCounter++;
           Resource r3 = ResourceFactory.createResource(baseURI + range.getLocalName() + "_" + idCounter);
 
           if (i == 0) {
             ttlWriter.triple(new Triple(r.asNode(), p.asNode(), r2.asNode()));
-            LOG.info("*OK 15*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r2.getLocalName());
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("*OK 15*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r2
+                              .getLocalName());
+            }
           }
           ttlWriter.triple(new Triple(r2.asNode(), ontModel.getOntProperty(LIST_NS + "hasContents").asNode(), r1.asNode()));
-          LOG.info("*OK 16*: added property: " + r2.getLocalName() + " - " + "-hasContents-" + " - " + r1.getLocalName());
-
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("*OK 16*: added property: " + r2.getLocalName() + " - " + "-hasContents-" + " - " + r1
+                            .getLocalName());
+          }
           if (i < el.size() - 1) {
             ttlWriter.triple(new Triple(r2.asNode(), ontModel.getOntProperty(LIST_NS + "hasNext").asNode(), r3.asNode()));
-            LOG.info("*OK 17*: added property: " + r2.getLocalName() + " - " + "-hasNext-" + " - " + r3.getLocalName());
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("*OK 17*: added property: " + r2.getLocalName() + " - " + "-hasNext-" + " - " + r3
+                              .getLocalName());
+            }
           }
         }
       }
@@ -831,7 +885,10 @@ public class RDFWriter {
         entlist.add((IFCVO) tmpList.get(i));
         if (i == 0) {
           ttlWriter.triple(new Triple(r.asNode(), p.asNode(), r1.asNode()));
-          LOG.info("*OK 13*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1.getLocalName());
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("*OK 13*: added property: " + r.getLocalName() + " - " + p.getLocalName() + " - " + r1
+                            .getLocalName());
+          }
         }
       }
     }
@@ -853,17 +910,26 @@ public class RDFWriter {
         rclass = ontModel.getOntResource(ontNS + typerange.getName());
         Resource r1 = getResource(baseURI + typerange.getName() + "_" + entlist.get(i).getLineNum(), rclass);
         ttlWriter.triple(new Triple(r.asNode(), listp.asNode(), r1.asNode()));
-        LOG.info("*OK 8*: created property: " + r.getLocalName() + " - " + listp.getLocalName() + " - " + r1.getLocalName());
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("*OK 8*: created property: " + r.getLocalName() + " - " + listp.getLocalName() + " - " + r1
+                          .getLocalName());
+        }
       } else {
         rclass = ontModel.getOntResource(ontNS + evorange.getName());
         Resource r1 = getResource(baseURI + evorange.getName() + "_" + entlist.get(i).getLineNum(), rclass);
         ttlWriter.triple(new Triple(r.asNode(), listp.asNode(), r1.asNode()));
-        LOG.info("*OK 9*: created property: " + r.getLocalName() + " - " + listp.getLocalName() + " - " + r1.getLocalName());
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("*OK 9*: created property: " + r.getLocalName() + " - " + listp.getLocalName() + " - " + r1
+                          .getLocalName());
+        }
       }
 
       if (i < reslist.size() - 1) {
         ttlWriter.triple(new Triple(r.asNode(), isfollowed.asNode(), reslist.get(i + 1).asNode()));
-        LOG.info("*OK 10*: created property: " + r.getLocalName() + " - " + isfollowed.getLocalName() + " - " + reslist.get(i + 1).getLocalName());
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("*OK 10*: created property: " + r.getLocalName() + " - " + isfollowed.getLocalName() + " - "
+                          + reslist.get(i + 1).getLocalName());
+        }
       }
     }
   }
@@ -886,17 +952,25 @@ public class RDFWriter {
         if (r2 == null) {
           r2 = ResourceFactory.createResource(baseURI + listrange.getLocalName() + "_" + idCounter);
           ttlWriter.triple(new Triple(r2.asNode(), RDF.type.asNode(), listrange.asNode()));
-          LOG.info("*OK 19*: created resource: " + r2.getLocalName());
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("*OK 19*: created resource: " + r2.getLocalName());
+          }
           idCounter++;
           propertyResourceMap.put(key, r2);
           addLiteralToResource(r2, valueProp, xsdType, literalString);
         }
         ttlWriter.triple(new Triple(r.asNode(), ontModel.getOntProperty(LIST_NS + "hasContents").asNode(), r2.asNode()));
-        LOG.info("*OK 11*: added property: " + r.getLocalName() + " - " + "-hasContents-" + " - " + r2.getLocalName());
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("*OK 11*: added property: " + r.getLocalName() + " - " + "-hasContents-" + " - " + r2
+                          .getLocalName());
+        }
 
         if (i < listelements.size() - 1) {
           ttlWriter.triple(new Triple(r.asNode(), ontModel.getOntProperty(LIST_NS + "hasNext").asNode(), reslist.get(i + 1).asNode()));
-          LOG.info("*OK 12*: added property: " + r.getLocalName() + " - " + "-hasNext-" + " - " + reslist.get(i + 1).getLocalName());
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("*OK 12*: added property: " + r.getLocalName() + " - " + "-hasNext-" + " - " + reslist.get(i + 1)
+                            .getLocalName());
+          }
         }
       }
     } else {

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,18 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="warn">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="be.ugent" level="info" />
+    <logger name="be.ugent.IfcSpfParser" level="debug" />
+
+</configuration>


### PR DESCRIPTION
* Use ArrayList of exactly the required size (-> less memory, faster in the mapping step)
* Resolve references during line parsing if possible ( -> less memory, faster in the mapping step)
* Only store full line in IFCVO if we want to deduplicate ( -> less memory)
* refactor code to reduce code duplication
* requires changes to IfcParserLib, which is a transitive dependency of ExpressToOwl, so that project's pom is required to change, too.