### PR TITLE
Add AbortSignal

### DIFF
--- a/src/main/java/be/ugent/progress/AbortSignal.java
+++ b/src/main/java/be/ugent/progress/AbortSignal.java
@@ -1,0 +1,23 @@
+package be.ugent.progress;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class AbortSignal {
+    private AtomicBoolean aborted;
+
+    public AbortSignal() {
+        this.aborted = new AtomicBoolean(false);
+    }
+
+    public void abort(){
+        this.aborted.set(true);
+    }
+
+    public void reset(){
+        this.aborted.set(false);
+    }
+
+    public boolean isAborted(){
+        return this.aborted.get();
+    }
+}

--- a/src/main/java/be/ugent/progress/StatefulTaskProgressListener.java
+++ b/src/main/java/be/ugent/progress/StatefulTaskProgressListener.java
@@ -21,6 +21,11 @@ public abstract class StatefulTaskProgressListener implements TaskProgressListen
         doNotifyFinished(task);
     }
 
+    @Override public void notifyFailed(String task) {
+        updateLatestTaskProgress(task, "failed", 0f);
+        doNotifyFailed(task);
+    }
+
     private void updateLatestTaskProgress(String task, String message, float i) {
         TaskProgress progress = new TaskProgress(task, message, i);
         TaskProgress prev = latestTaskProgress.put(task, progress);
@@ -40,6 +45,15 @@ public abstract class StatefulTaskProgressListener implements TaskProgressListen
     abstract public void doNotifyProgress(String task, String message, float level);
 
     abstract public void doNotifyFinished(String task);
+
+    abstract public void doNotifyFailed(String task);
+
+    /**
+     * Clears the state.
+     */
+    public void reset(){
+        this.latestTaskProgress.clear();
+    }
 
     public static class TaskProgress {
         private String task;

--- a/src/main/java/be/ugent/progress/TaskProgressListener.java
+++ b/src/main/java/be/ugent/progress/TaskProgressListener.java
@@ -22,4 +22,9 @@ public interface TaskProgressListener {
      */
     void notifyFinished(String task);
 
+    /**
+     * Informs the listener that the specified task was aborted or failed.
+     * @param task
+     */
+    void notifyFailed(String task);
 }

--- a/src/main/java/be/ugent/progress/TaskProgressReporter.java
+++ b/src/main/java/be/ugent/progress/TaskProgressReporter.java
@@ -106,6 +106,12 @@ public class TaskProgressReporter {
         }
     }
 
+    public void failed(){
+        if (this.progressListener != null){
+            this.progressListener.notifyFailed(this.taskName);
+        }
+    }
+
     private void adjustStepAndReportIfNewStep() {
         if (isNewstep()) {
             synchronized (this) {

--- a/src/test/java/be/ugent/TestIfcSpfReader.java
+++ b/src/test/java/be/ugent/TestIfcSpfReader.java
@@ -111,6 +111,10 @@ public class TestIfcSpfReader {
             public void notifyFinished(String task) {
                 logger.debug("{}: {} ({}%)", task, "finished", String.format("%d", 100));
             }
+
+            @Override public void notifyFailed(String task) {
+                logger.debug("{}: {}", task, "failed");
+            }
         });
         reader.convert(file.getAbsolutePath(), StreamRDFLib.sinkTriples(new Sink<Triple>() {
             long size = 0;


### PR DESCRIPTION
Allows the client to abort the potentially lenghty conversion process.

Also fixes the RDFWriter to actually use a bounded queue for decoupling producer and consumer threads (as intended, but not implemented before)
